### PR TITLE
Version 14: Distroless Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v14.0.0
+
+* **[2025-08-16 19:07:33 CDT]** Upgraded to the latest PHP.
+* **[2025-08-17 19:11:13 CDT]** [major] Converted all of the PHP base images to distroless, saving 500 MB per image.
+
 ## v13.0.3
 * **[2025-07-03 02:54:38 CDT]** Fixed the ext-builder.
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Current PHP versions:
 * PHP 7.1.33-67+ubuntu24.04.1+deb.sury.org+1 (cli) (built: Dec 24 2024 06:50:54) ( NTS )
 * PHP 7.2.34-54+ubuntu24.04.1+deb.sury.org+1 (cli) (built: Dec 24 2024 06:58:15) ( NTS )
 * PHP 7.3.33-24+ubuntu24.04.1+deb.sury.org+1 (cli) (built: Dec 24 2024 07:05:25) ( NTS )
-* PHP 7.4.33 (cli) (built: May  9 2025 06:45:02) ( NTS )
-* PHP 8.0.30 (cli) (built: Mar 13 2025 18:34:50) ( NTS )
-* PHP 8.1.32 (cli) (built: Mar 13 2025 18:27:44) (NTS)
-* PHP 8.2.28 (cli) (built: Mar 13 2025 18:13:49) (NTS)
-* PHP 8.3.22 (cli) (built: Jun  9 2025 14:03:36) (NTS)
-* PHP 8.4.8 (cli) (built: Jun  9 2025 13:50:18) (NTS)
+* PHP 7.4.33 (cli) (built: Jul  3 2025 16:41:49) ( NTS )
+* PHP 8.0.30 (cli) (built: Jul  3 2025 16:39:43) ( NTS )
+* PHP 8.1.33 (cli) (built: Jul  3 2025 16:16:18) (NTS)
+* PHP 8.2.29 (cli) (built: Jul  3 2025 13:08:18) (NTS)
+* PHP 8.3.24 (cli) (built: Aug  3 2025 08:58:02) (NTS)
+* PHP 8.4.11 (cli) (built: Aug  3 2025 08:42:27) (NTS)
 
 The `phpexperts/php:VESION-full` images contain every bundled PHP extension, and Redis.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Current PHP versions:
 * PHP 8.3.24 (cli) (built: Aug  3 2025 08:58:02) (NTS)
 * PHP 8.4.11 (cli) (built: Aug  3 2025 08:42:27) (NTS)
 
-The `phpexperts/php:VESION-full` images contain every bundled PHP extension, and Redis.
+The `phpexperts/php:${PHP_VERSION}-full` images contain every bundled PHP extension, and Redis.
 
 * imap
 * ldap
@@ -64,9 +64,9 @@ Then edit credentials in .env.
     composer require --dev phpexperts/dockerize
     vendor/bin/php dockerize
     # Edit credentials in .env.
-    docker-compose up -d
+    docker compose up -d
 
-Don't forget to edit your docker-compose.yml!
+Don't forget to edit your docker compose.yml!
 
 ### Configure your PATH
 
@@ -111,6 +111,11 @@ It will then automagically update composer and run the appropriate version of PH
 supported by your project via the power of Docker.
 
 ## Latest Changes
+
+#### v14.0.0: Distroless Images
+
+* **[2025-08-16 19:07:33 CDT]** Upgraded to the latest PHP.
+* **[2025-08-17 19:11:13 CDT]** [major] Converted all of the PHP base images to distroless, saving 500 MB per image.
 
 #### v13.0.3
 * **[2025-07-03 02:54:38 CDT]** Fixed the ext-builder.
@@ -187,39 +192,16 @@ supported by your project via the power of Docker.
 * **[2024-08-05 03:46:54 CDT]** Added support for PHP 8.4 Alpha 4.
 * **[2024-08-05 04:33:33 CDT]** Added a bash installation script to the composer package.
 
-#### v10.0.3
-* **[2024-06-29 10:13:12 CDT]** [php-ci] Dynamically fetch and compute the supported PHP versions from the composer.json.
-* **[2024-06-29 10:20:39 CDT]** [php-ci] Use phpunit's default config if there aren't version-specific xmls.
-* **[2024-06-29 10:20:48 CDT]** [php-ci] Added support for PHPUnit v11.
-* **[2024-06-29 10:31:50 CDT]** Create a Packagist alias to phpexperts/dockerise for SEO.
+## Manage with docker compose
 
-#### v10.0.2
-* **[2024-06-26 00:57:05 CDT]** Added my php-ci.sh script.
-
-#### v10.0.0
-* **[2024-05-24 07:40:15 CDT]** Added a comprehensive zero-dependency Bash-via-curl installer.
-* **[2024-05-24 07:31:26 CDT]** Added a mechanism for finding the first open HTTP port for nginx. master
-* **[2024-05-24 07:30:16 CDT]** Redis removed v7.3 from docker; switched to v7.2.
-
-#### v9.2.1
-* **[2024-05-23 08:17:00 CDT]** Upgraded to MariaDB 10.11, Redis 7.3, and Postgres 16.
-
-#### v9.2.0
-* **[2024-05-21 21:31:26 CDT]** Configured it so that composer will run the install script. 
-
-#### v9.1.2
-* **[2024-05-21 06:27:48 CDT]** Fixes docker logs being truncated. origin/v9.
-
-## Manage with docker-compose
-
-To control the containers, use `docker-compose`.
+To control the containers, use `docker compose`.
   
     # Downloads the images, creates and launches the containers.
-    docker-compose up -d
+    docker compose up -d
     # View the logs
-    docker-compose logs -ft
+    docker compose logs -ft
     # Stop the containers
-    docker-compose stop
+    docker compose stop
 
 That's it! You now have the latest LEPP (Linux, Nginx, PostgreSQL, PHP) stack or
 the latest LEMP (Linux, Nginx, MariaDB, PHP) stack.

--- a/docker/build-distroless.sh
+++ b/docker/build-distroless.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#####################################################################
+#   The Dockerize PHP Project                                       #
+#   https://github.com/PHPExpertsInc/docker-php                     #
+#   License: MIT                                                    #
+#                                                                   #
+#   Copyright © 2020-2025 PHP Experts, Inc. <sales@phpexperts.pro>  #
+#       Author: Theodore R. Smith <theodore@phpexperts.pro>         #
+#      PGP Sig: 4BF826131C3487ACD28F2AD8EB24A91DD6125690            #
+#####################################################################
+
+set -o pipefail
+
+PHP_VERSIONS="5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4"
+#PHP_VERSIONS="7.4 8.0 8.1 8.2 8.3 8.4"
+#PHP_VERSIONS="8.0 8.1 8.2 8.3 8.4"
+
+# Create the apt cache volume
+docker volume create apt-cache
+
+export BUILDKIT_STEP_LOG_MAX_SIZE=104857600
+
+# Build the base linux image first.
+export DOCKER_BUILDKIT=1
+
+
+for VERSION in ${PHP_VERSIONS}; do
+    # Check if the base image exists and get its size
+    if ! docker image inspect "phpexperts/php:${VERSION}" >/dev/null 2>&1; then
+        echo "Docker image phpexperts/php:${VERSION} does not exist. Skipping..."
+        continue
+    fi
+    
+    # Get image size in bytes and convert to MB
+    IMAGE_SIZE_BYTES=$(docker image inspect "phpexperts/php:${VERSION}" --format='{{.Size}}')
+    IMAGE_SIZE_MB=$((IMAGE_SIZE_BYTES / 1024 / 1024))
+    
+    if [ $IMAGE_SIZE_MB -le 200 ]; then
+        echo "Docker image phpexperts/php:${VERSION} is ${IMAGE_SIZE_MB}MB (≤200MB). Skipping..."
+        continue
+    fi
+    
+    echo "Building distroless image for PHP ${VERSION} (base image size: ${IMAGE_SIZE_MB}MB)..."
+    
+    # Build the distroless image
+    if docker build distroless --tag="phpexperts/php:${VERSION}-distroless" --build-arg VOLUME="apt-cache:/var/lib/apt" --build-arg PHP_VERSION=$VERSION --no-cache --progress=plain; then
+        echo "Successfully built distroless image for PHP ${VERSION}"
+        
+        # Remove the existing image (force)
+        docker rmi -f "phpexperts/php:${VERSION}"
+        
+        # Tag the distroless image as the main version
+        docker tag "phpexperts/php:${VERSION}-distroless" "phpexperts/php:${VERSION}"
+        
+        # Remove the distroless tagged image
+        docker rmi "phpexperts/php:${VERSION}-distroless"
+        
+        echo "Successfully replaced phpexperts/php:${VERSION} with distroless version"
+    else
+        echo "Failed to build distroless image for PHP ${VERSION}"
+    fi
+done

--- a/docker/distroless/Dockerfile
+++ b/docker/distroless/Dockerfile
@@ -1,0 +1,32 @@
+# PROMPT: Create an intermediary Dockerfile from phpexperts/php:8.3 that copies the "grab_files.sh" bash script
+#         created previously. RUN the /grab_files.sh multiple times with the args /usr/bin/bash, /usr/bin/env, /usr/bin/php,
+#         /usr/bin/composer /usr/bin/ls and /etc/php/8.3, /usr/share/zoneinfo, /etc/ssl/certs, each on its own line.
+#
+#         Then using a FROM scratch final image, COPY the path /tmp/distroless to / of the final image.
+#         Also COPY /usr/local/bin/entrypoint-php.sh to the final image.
+#         Set the CMD to /usr/bin/php and the ENTRYPOINT to /usr/local/bin/entrypoint-php.sh.
+ARG PHP_VERSION
+
+FROM phpexperts/php:$PHP_VERSION AS intermediate
+
+COPY grab_files.sh /grab_files.sh
+
+RUN /grab_files.sh "/usr/bin/bash" || true
+RUN /grab_files.sh "/usr/bin/env"; \
+    /grab_files.sh "/usr/bin/ldd"; \
+    /grab_files.sh "/usr/bin/php"; \
+    /grab_files.sh "/usr/local/bin/composer"; \
+    /grab_files.sh "/usr/bin/ls"; \
+    /grab_files.sh "/usr/lib/php"; \
+    /grab_files.sh "/etc/php/$PHP_VERSION"; \
+    /grab_files.sh "/usr/share/zoneinfo"; \
+    /grab_files.sh "/etc/ca-certificates/" || true
+
+FROM scratch
+
+COPY --from=intermediate /tmp/distroless /
+COPY --from=intermediate /usr/local/bin/entrypoint-php.sh /usr/bin/entrypoint-php.sh
+
+WORKDIR /workdir
+
+ENTRYPOINT ["/usr/bin/entrypoint-php.sh"]

--- a/docker/distroless/grab_files.sh
+++ b/docker/distroless/grab_files.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# PROMPT: Create a bash script with the following:
+#  If a CLI arg is not passed, fail with the mesage "Error: Pass the full path of the file/executable you want to include."
+#
+# If the CLI arg is neither a file nor a directory, fail with the message "Error: File not found."
+#
+# If the /tmp/distroless directory does not exist, create it. Then
+#     cd into /tmp/distroless and create the POSIX standard Linux directories, using Ubuntu 22.04 as the exact model to copy.
+#     set chmod 0777 for tmp var/{cache,log,tmp}
+#     set chmod 0750 for root
+#     Create ln -s for /bin /sbin from /usr/bin
+#     Create ln -s for /lib /lib64 from /usr/lib
+#
+# Then if the CLI arg is a directory, use the following prompt:
+#     If the SOURCE directory (via the CLI arg) is "/etc/php/8.3", 
+#         Copy this to /tmp/distroless/ while maintaining the relative directory path: 
+#             Example: /etc/php/8.3 -> /tmp/distroless/etc/php/8.3/
+#
+# If it is not a directory:
+#     cp -v "$1" "/tmp/distroless$1"
+#     Test if the file is an executable (via bash's -x).
+#     If it is an executable:
+#     Then run `ldd "$1" | awk '{print $1}'` and use `cp` to copy the files to /usr/lib
+#         Ignore any errors from the `cp` command, as they are likely false-positives.
+#
+# Include this exact prompt as a source code comment at the beginning of the Bash script.
+# Do not bother with inline comments.
+if [ -x "$1" ]; then
+    cd /usr/lib/x86_64-linux-gnu
+    cp -vf $(ldd "$1" | awk '{print $1}') /tmp/distroless/usr/lib/
+fi
+
+
+
+if [ -z "$1" ]; then
+    echo "Error: Pass the full path of the file/executable you want to include."
+    exit 1;
+fi
+
+if [ ! -f "$1" ] && [ ! -d "$1" ]; then
+    echo "Error: File not found."
+    exit 2;
+fi
+
+if [ ! -d /tmp/distroless ]; then
+    mkdir -p /tmp/distroless
+    cd /tmp/distroless
+    mkdir -p dev etc home/user media mnt opt proc root run sys tmp usr var/{cache,lib,log,spool,tmp}
+    mkdir -p /tmp/distroless/usr/{bin,lib,local/bin}
+
+    chmod 0777 tmp var/{cache,log,tmp}
+    chmod 0750 root
+
+    ln -s usr/bin bin
+    ln -s usr/bin sbin
+    ln -s usr/lib lib
+    ln -s usr/lib lib64
+fi
+
+if [ -d "$1" ]; then
+
+    cp -avf --parents "$1" /tmp/distroless
+
+    for each in $(find "$1" -name \*.so\* -type f); do 
+        cd /usr/lib/x86_64-linux-gnu
+        cp -v $(ldd $each | awk '{print $1}') /tmp/distroless/usr/lib
+    done
+
+    exit 0
+fi
+
+cp -v "$1" "/tmp/distroless$1"
+if [ -x "$1" ]; then
+    cd /usr/lib/x86_64-linux-gnu
+    cp -vf $(ldd "$1" | awk '{print $1}') /tmp/distroless/usr/lib/
+fi

--- a/php_versions.txt
+++ b/php_versions.txt
@@ -1,0 +1,45 @@
+^C^CPHP 5.6.40-86+ubuntu24.04.1+deb.sury.org+1 (cli) 
+Copyright (c) 1997-2016 The PHP Group
+Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
+    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
+PHP 7.0.33-79+ubuntu24.04.1+deb.sury.org+1 (cli) (built: Dec 24 2024 06:43:22) ( NTS )
+Copyright (c) 1997-2017 The PHP Group
+Zend Engine v3.0.0, Copyright (c) 1998-2017 Zend Technologies
+    with Zend OPcache v7.0.33-79+ubuntu24.04.1+deb.sury.org+1, Copyright (c) 1999-2017, by Zend Technologies
+PHP 7.1.33-67+ubuntu24.04.1+deb.sury.org+1 (cli) (built: Dec 24 2024 06:50:54) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.1.33-67+ubuntu24.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
+PHP 7.2.34-54+ubuntu24.04.1+deb.sury.org+1 (cli) (built: Dec 24 2024 06:58:15) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.2.34-54+ubuntu24.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
+PHP 7.3.33-24+ubuntu24.04.1+deb.sury.org+1 (cli) (built: Dec 24 2024 07:05:25) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.3.33, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.3.33-24+ubuntu24.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
+PHP 7.4.33 (cli) (built: Jul  3 2025 16:41:49) ( NTS )
+Copyright (c) The PHP Group
+Zend Engine v3.4.0, Copyright (c) Zend Technologies
+    with Zend OPcache v7.4.33, Copyright (c), by Zend Technologies
+PHP 8.0.30 (cli) (built: Jul  3 2025 16:39:43) ( NTS )
+Copyright (c) The PHP Group
+Zend Engine v4.0.30, Copyright (c) Zend Technologies
+    with Zend OPcache v8.0.30, Copyright (c), by Zend Technologies
+PHP 8.1.33 (cli) (built: Jul  3 2025 16:16:18) (NTS)
+Copyright (c) The PHP Group
+Zend Engine v4.1.33, Copyright (c) Zend Technologies
+    with Zend OPcache v8.1.33, Copyright (c), by Zend Technologies
+PHP 8.2.29 (cli) (built: Jul  3 2025 13:08:18) (NTS)
+Copyright (c) The PHP Group
+Zend Engine v4.2.29, Copyright (c) Zend Technologies
+    with Zend OPcache v8.2.29, Copyright (c), by Zend Technologies
+PHP 8.3.24 (cli) (built: Aug  3 2025 08:58:02) (NTS)
+Copyright (c) The PHP Group
+Zend Engine v4.3.24, Copyright (c) Zend Technologies
+    with Zend OPcache v8.3.24, Copyright (c), by Zend Technologies
+PHP 8.4.11 (cli) (built: Aug  3 2025 08:42:27) (NTS)
+Copyright (c) The PHP Group
+Built by Debian
+Zend Engine v4.4.11, Copyright (c) Zend Technologies
+    with Zend OPcache v8.4.11, Copyright (c), by Zend Technologies


### PR DESCRIPTION

* **[2025-08-16 19:07:33 CDT]** Upgraded to the latest PHP.
* **[2025-08-17 19:11:13 CDT]** [major] Converted all of the PHP base images to distroless, saving 500 MB per image.
